### PR TITLE
fixed irritating class(x) == bug

### DIFF
--- a/R/get_results.R
+++ b/R/get_results.R
@@ -13,7 +13,7 @@ fix_columns = function(questions, completed){
 }
 
 get_linux_time = function(x) {
-  if(class(x) == "Date") x = as.POSIXct(x)
+  if(inherits(x,"Date")) x = as.POSIXct(x)
   as.integer(x)
 }
 


### PR DESCRIPTION
This gave annoying warnings on multiclass objects, may cause odd behaviour with some date/time objects 
and is bad practice anyway